### PR TITLE
(Update): Logs, Fallback, User Info for Fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ cython_debug/
 
 # Nadocast
 Nadocast
+
+logs/

--- a/functions.py
+++ b/functions.py
@@ -83,7 +83,6 @@ async def getNadoCastData(time: datetime) -> list[str]:
             day, month, year, timeNow
         )
 
-    
     if os.path.exists(folder_location) and os.listdir(folder_location) != []:
         for file in os.listdir(folder_location):
             file_list.append(os.path.join(folder_location, file))
@@ -93,7 +92,7 @@ async def getNadoCastData(time: datetime) -> list[str]:
             f"Images for {timeNow}z have already been downloaded, returning them instead of downloading new ones."
         )
         return file_list
-    
+
     response = requests.get(url)
 
     if not os.path.exists(folder_location):

--- a/functions.py
+++ b/functions.py
@@ -43,17 +43,62 @@ async def getNadoCastData(time: datetime) -> list[str]:
 
     # Folder Structure, and create the folder if it doesn't exist, but if it does, return the already downloaded images
     folder_location = r"Nadocast\\{1}_{0}_{2}_{3}z".format(day, month, year, timeNow)
-    if os.path.exists(folder_location):
+
+    # Get the html text from the url
+
+    await log(f"Fetching images for {timeNow}z (from {url})")
+
+    response = requests.get(url)
+
+    # Check if the response is valid
+    if response.status_code != 200:
+        # Create fallback
+
+        time = time - timedelta(hours=6)
+
+        month = time.strftime("%m")
+        day = time.strftime("%d")
+        year = time.strftime("20%y")
+        timeNow = time.strftime("%H")
+        timeNowInt = int(timeNow)
+
+        if timeNowInt < 13:
+            timeNow = 0
+        elif 13 <= timeNowInt < 18:
+            timeNow = 12
+        elif 18 <= timeNowInt < 24:
+            timeNow = 18
+
+        url = "{4}{2}{1}/{2}{1}{0}/t{3}z/".format(
+            day, month, year, timeNow, os.getenv("URL")
+        )
+
+        await log(
+            f"Previous URL was 404, had to fallback, fetching images for {timeNow}z (from {url})"
+        )
+
+        # Since the data is only available at 0Z, 12Z, 18Z, we need to round the time to the nearest available time
+
+        folder_location = r"Nadocast\\{1}_{0}_{2}_{3}z".format(
+            day, month, year, timeNow
+        )
+
+    
+    if os.path.exists(folder_location) and os.listdir(folder_location) != []:
         for file in os.listdir(folder_location):
             file_list.append(os.path.join(folder_location, file))
         file_list.sort()
+        # await log(f"Images fetched for {timeNow}z: {file_list}")
+        await log(
+            f"Images for {timeNow}z have already been downloaded, returning them instead of downloading new ones."
+        )
         return file_list
+    
+    response = requests.get(url)
 
     if not os.path.exists(folder_location):
+        await log(f"Had to create a new folder ({folder_location})")
         os.makedirs(folder_location)
-
-    # Get the html text from the url
-    response = requests.get(url)
 
     # Parse the html text
     soup = BeautifulSoup(response.text, "html.parser")
@@ -68,12 +113,29 @@ async def getNadoCastData(time: datetime) -> list[str]:
         with open(filename, "wb") as f:
             f.write(requests.get(urljoin(url, link["href"])).content)
 
+    sepeartor = " ,"
+    text = sepeartor.join(file_list)
+    if text == "":
+        text = "No images found"
+    # await log(f"Images fetched for {timeNow}z: {file_list}")
+    await log(f"New images have been downloaded for {timeNow}z, returning them.")
+
     file_list.sort()
+
+    # OLD CODE, KEPT incase this does get triggered, meaning the list is somehow empty when that should not be possible.
     if len(file_list) == 0:
-        os.rmdir(folder_location)
-        with open("error.log", "a") as f:
+        with open("logs/error.log", "a") as f:
             f.write(
-                f"{datetime.now()} - No images found for {folder_location}. Command locked for 1 minute. Folder deleted. \n"
+                f"{datetime.now()} - No images found for {folder_location}. Command locked for 1 minute. [THIS SHOULD NOT TRIGGER]\n"
             )
         return None
     return file_list
+
+
+async def log(*params):
+    if not os.path.exists("logs"):
+        os.makedirs("logs")
+    with open("logs/general.log", "a") as f:
+        seperator = " "
+        text = seperator.join(params)
+        f.write(f"{datetime.now()} - {text} \n")

--- a/main.py
+++ b/main.py
@@ -69,8 +69,11 @@ async def fetch(ctx, *args) -> None:
     elif 18 <= timeNowInt < 24:
         timeNow = 18
 
+    # This shouldn't trigger, but if it does, something went wrong.
     if result == None:
-        await log(f"Error: No images found for {timeNow}Z, current UTC is {timeNowInt}z.")
+        await log(
+            f"Error: No images found for {timeNow}Z, current UTC is {timeNowInt}z."
+        )
         await ctx.send(
             f"It appears Nadocast has not put out the new images for this time range ({timeNow}z)! Please try again in a minute."
         )
@@ -125,7 +128,7 @@ async def fetch(ctx, *args) -> None:
         elif 18 <= hour < 24:
             hour = 18
         text = f"Sorry! It appears Nadocast hasn't uploaded the images for {timeNow}z, here are {hour}z's instead!"
-        
+
     await ctx.send(text, files=files)
 
 

--- a/main.py
+++ b/main.py
@@ -54,16 +54,29 @@ async def fetch(ctx, *args) -> None:
         return await ctx.send("Please wait a minute before using this command again!")
 
     await ctx.send("Fetching... please wait.")
-
+    UTC = await getUTCTime()
     # Fetch data, get our list of images
-    result = await getNadoCastData(await getUTCTime())
+    result = await getNadoCastData(UTC)
+
+    timeNow = UTC.strftime("%H")
+    timeNowInt = int(timeNow)
+
+    # Since the data is only available at 0Z, 12Z, 18Z, we need to round the time to the nearest available time
+    if timeNowInt < 13:
+        timeNow = 0
+    elif 13 <= timeNowInt < 18:
+        timeNow = 12
+    elif 18 <= timeNowInt < 24:
+        timeNow = 18
+
     if result == None:
+        await log(f"Error: No images found for {timeNow}Z, current UTC is {timeNowInt}z.")
         await ctx.send(
-            "It appears Nadocast has not put out the new images for this time range! Please try again in a minute."
+            f"It appears Nadocast has not put out the new images for this time range ({timeNow}z)! Please try again in a minute."
         )
         cooldown["last_used"] = datetime.now().timestamp()
         return
-    # print(result)
+
     # Send the images
     files = []
     # debug = []
@@ -96,7 +109,24 @@ async def fetch(ctx, *args) -> None:
         )
     # debug.sort()
     # await ctx.send(debug)
-    await ctx.send(files=files)
+    text = ""
+
+    if f"{timeNow}z" in result[0]:
+        text = f"Here are the images for {timeNow}z!"
+    else:
+        UTC = UTC - timedelta(hours=6)
+
+        hour = int(UTC.strftime("%H"))
+
+        if hour < 13:
+            hour = 0
+        elif 13 <= hour < 18:
+            hour = 12
+        elif 18 <= hour < 24:
+            hour = 18
+        text = f"Sorry! It appears Nadocast hasn't uploaded the images for {timeNow}z, here are {hour}z's instead!"
+        
+    await ctx.send(text, files=files)
 
 
 if type(TOKEN) == type(None):


### PR DESCRIPTION
This should fix #8.
How? Created a fallback to the previous time (18z -> 12z, 12z -> 0z, etc) and used those images instead. 
Also created some logs to help track this info. 

Example log:
```log
2024-07-11 15:22:22.755464 - Fetching images for 18z (from http://data.nadocast.com/202407/20240711/t18z/) 
2024-07-11 15:22:22.845909 - Previous URL was 404, had to fallback, fetching images for 12z (from http://data.nadocast.com/202407/20240711/t12z/) 
2024-07-11 15:22:22.846909 - Images for 12z have already been downloaded, returning them instead of downloading new ones. 
2024-07-11 15:22:24.170061 - Fetching images for 18z (from http://data.nadocast.com/202407/20240711/t18z/) 
2024-07-11 15:22:24.254512 - Previous URL was 404, had to fallback, fetching images for 12z (from http://data.nadocast.com/202407/20240711/t12z/) 
2024-07-11 15:22:24.257607 - Images for 12z have already been downloaded, returning them instead of downloading new ones. 
2024-07-11 15:22:26.022429 - Fetching images for 18z (from http://data.nadocast.com/202407/20240711/t18z/) 
2024-07-11 15:22:26.107704 - Previous URL was 404, had to fallback, fetching images for 12z (from http://data.nadocast.com/202407/20240711/t12z/) 
2024-07-11 15:22:26.108714 - Images for 12z have already been downloaded, returning them instead of downloading new ones. 
```

User also gets notified if we had to rollback a time range. Stating that f"Sorry! It appears Nadocast hasn't uploaded the images for {timeNow}z, here are {hour}z's instead!"
Where {timeNow} is the inital request, {hour} is what is sent back.
